### PR TITLE
Fix 'pre-commit/commit-string-warn` git hook

### DIFF
--- a/pre-commit/commit-string-warn.sh
+++ b/pre-commit/commit-string-warn.sh
@@ -14,10 +14,10 @@ warn_if_trying_to_commit() {
   # Enable getting interactive input from user
   exec < /dev/tty
 
-  [[ -n "`git grep --cached \"$1\"`" ]] && local has_string=true || local has_string=false
+  [[ -n "`git diff-index --cached -S\"$1\"`HEAD" ]] && local has_string=true || local has_string=false
 
   if [[ $has_string == true ]]; then
-    local file=`git grep --cached --name-only "$1"`
+    local file=`git diff-index --cached --name-only "$1" HEAD`
     echo ""
     echo -e "${red}$file ${cyan}contains the string ${red}'$1'${normal}"
     read -p "Are you sure you want to commit it? ${red}(y/N)${normal} " answer


### PR DESCRIPTION
Use `diff-index` instead of `grep`
